### PR TITLE
fix: retry on session decrypt error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,3 @@ Versions use date-based versioning: YYYY.MM.DD.
 - Moved decrypted response logs to debug level.
 - Removed unused `tp-connected` dependency.
 - Replaced deprecated `datetime.utcnow()` usage with `datetime.now(UTC)`.
-- Retry login when session decryption fails to avoid padding errors.


### PR DESCRIPTION
## Intent
Make session validation rely on the modem's `result` field instead of decrypt-retry logic.

## Changes
- `_is_success_response` now treats non-negative `result` as valid
- removed decrypt-retry logic introduced in this branch
- ignore `.run/` from version control

## Risks
- if devices return non-standard `result` values, validation may be stricter

## Testing
- not run
